### PR TITLE
Support Stacktrace filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ var logger = Logger(
     lineLength: 120, // width of the output
     colors: true, // Colorful log messages
     printEmojis: true, // Print an emoji for each log message
-    printTime: false // Should each log print contain a timestamp
+    printTime: false, // Should each log print contain a timestamp
+    stacktraceFilters: [], // Add some filters to exclude some stacktrace entries
   ),
 );
 ```

--- a/README.md
+++ b/README.md
@@ -82,8 +82,7 @@ var logger = Logger(
     lineLength: 120, // width of the output
     colors: true, // Colorful log messages
     printEmojis: true, // Print an emoji for each log message
-    printTime: false, // Should each log print contain a timestamp
-    stacktraceFilters: [], // Add some filters to exclude some stacktrace entries
+    printTime: false // Should each log print contain a timestamp
   ),
 );
 ```

--- a/lib/src/printers/pretty_printer.dart
+++ b/lib/src/printers/pretty_printer.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 
-import 'package:logger/src/logger.dart';
-import 'package:logger/src/log_printer.dart';
 import 'package:logger/src/ansi_color.dart';
+import 'package:logger/src/log_printer.dart';
+import 'package:logger/src/logger.dart';
 
 /// Default implementation of [LogPrinter].
 ///
@@ -74,6 +74,7 @@ class PrettyPrinter extends LogPrinter {
   final bool colors;
   final bool printEmojis;
   final bool printTime;
+  final List<RegExp> stacktraceFilters;
 
   /// To prevent ascii 'boxing' of any log [Level] include the level in map for excludeBox,
   /// for example to prevent boxing of [Level.verbose] and [Level.info] use excludeBox:{Level.verbose:true, Level.info:true}
@@ -99,6 +100,7 @@ class PrettyPrinter extends LogPrinter {
     this.printTime = false,
     this.excludeBox = const {},
     this.noBoxingByDefault = false,
+    this.stacktraceFilters = const [],
   }) {
     _startTime ??= DateTime.now();
 
@@ -159,6 +161,7 @@ class PrettyPrinter extends LogPrinter {
       if (_discardDeviceStacktraceLine(line) ||
           _discardWebStacktraceLine(line) ||
           _discardBrowserStacktraceLine(line) ||
+          _discardUserStacktraceLine(line) ||
           line.isEmpty) {
         continue;
       }
@@ -200,6 +203,9 @@ class PrettyPrinter extends LogPrinter {
     return match.group(1)!.startsWith('package:logger') ||
         match.group(1)!.startsWith('dart:');
   }
+
+  bool _discardUserStacktraceLine(String line) =>
+      stacktraceFilters.any((element) => element.hasMatch(line));
 
   String getTime() {
     String _threeDigits(int n) {


### PR DESCRIPTION
# Description:
If you wrap the logger in a custom logger file, the first line of the stack trace is your wrapper class (and it's not useful).

So if you have this:

```dart
import 'package:logger/logger.dart' as dart_log;

abstract class Logger {
  static final dart_log.Logger _instance = dart_log.Logger(
    printer: dart_log.PrettyPrinter(),
  );

  static void v(dynamic message, [dynamic error, StackTrace? stackTrace]) =>
      _instance.log(dart_log.Level.verbose, message, error, stackTrace);

  static void d(dynamic message, [dynamic error, StackTrace? stackTrace]) =>
      _instance.log(dart_log.Level.debug, message, error, stackTrace);

```
Then you call `Logger.d()`, the first stacktrace entry logger is not useful.

To solve that, I added a  `stacktraceFilters`, which enables you to define custom filters.
So, now you can do something like:
```dart
  static final dart_log.Logger _instance = dart_log.Logger(
    printer: dart_log.PrettyPrinter(
      stacktraceFilters: [
        RegExp(r'^(packages/.*/core/source/common/logger.dart).*')
      ],
    ),
  );
  ```